### PR TITLE
Fixed TensorFlow dependency (TensorFlow 2 release)

### DIFF
--- a/requirements-pip.txt
+++ b/requirements-pip.txt
@@ -1,6 +1,6 @@
 numpy>=1.13.3
 scipy>=1.0.0
-tensorflow-gpu>=1.6.0
+tensorflow-gpu==1.6.0
 moviepy>=0.2.3.2
 Pillow>=3.1.1
 lmdb>=0.93


### PR DESCRIPTION
Listing TensorFlow dependency as ```tensorflow-gpu>=1.6.0``` gives compatibility errors as TensorFlow 2 was released, with major changes.