### PR TITLE
removed a literal comparison pitfall from the code

### DIFF
--- a/tfutil.py
+++ b/tfutil.py
@@ -176,7 +176,7 @@ def finalize_autosummaries():
 def _create_autosummary_var(name, value_expr):
     assert not _autosummary_finalized
     v = tf.cast(value_expr, tf.float32)
-    if v.shape.ndims is 0:
+    if v.shape.ndims == 0:
         v = [v, np.float32(1.0)]
     elif v.shape.ndims is 1:
         v = [tf.reduce_sum(v), tf.cast(tf.shape(v)[0], tf.float32)]


### PR DESCRIPTION
**The problem**
In Python when comparing to non-singleton values, it advised to use the operator '==' instead of 'is'.
By doing otherwise, we may fall into the a code pitfall which can be detected by pylint under the identification of R0123 literal-comparison https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/R0123.html

**The solution**
Refactored the comparison on the the literal